### PR TITLE
Fix mobile viewport and dynamic height

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,8 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Meta viewport ensures proper scaling on mobile devices */}
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         {/* Removed direct Google Fonts links, relying on next/font */}
       </head>
       <body className={`${inter.variable} font-sans antialiased`}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,8 @@ import { KGPTChat } from '@/components/kgpt-chat/index'; // Explicitly point to 
 export default function Home() {
   return (
     // Updated styling for overall page to use theme variables and fill the screen
-    <main className="flex justify-center items-center min-h-svh bg-gradient-to-br from-background to-secondary">
-      <div className="w-full h-svh">
+    <main className="flex justify-center items-center min-h-dvh bg-gradient-to-br from-background to-secondary">
+      <div className="w-full h-dvh">
         <KGPTChat />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- ensure proper mobile scaling with viewport meta tag
- switch page layout to use dynamic viewport height

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855153d1a208321a423d8d4c9553749