### PR TITLE
Fix mobile viewport cropping

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -126,9 +126,13 @@
   * {
     @apply border-border;
   }
+  html {
+    height: 100%;
+  }
   body {
     @apply bg-gradient-to-br from-background to-secondary text-foreground font-sans;
     font-feature-settings: "rlig" 1, "calt" 1; /* Enable ligatures and contextual alternates */
+    min-height: calc(var(--app-height, 100dvh));
   }
   /* Markdown styling within chat bubbles */
   .markdown-content p { @apply mb-2 last:mb-0; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,13 +20,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="h-full" suppressHydrationWarning>
       <head>
         {/* Meta viewport ensures proper scaling on mobile devices */}
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         {/* Removed direct Google Fonts links, relying on next/font */}
       </head>
-      <body className={`${inter.variable} font-sans antialiased`}>
+      <body className={`${inter.variable} font-sans antialiased h-full`}>
         <ViewportHeightWrapper>
           <ThemeProviderWrapper>
             {children}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google'; // Import Inter
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster";
-import { ThemeProviderWrapper } from '@/components/theme-provider-wrapper'; // Import new wrapper
+import { ThemeProviderWrapper } from '@/components/theme-provider-wrapper'; // Import theme wrapper
+import { ViewportHeightWrapper } from '@/components/viewport-height-wrapper';
 
 // Configure Inter font
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
@@ -21,13 +22,17 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Meta viewport ensures proper scaling on mobile devices */}
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         {/* Removed direct Google Fonts links, relying on next/font */}
       </head>
       <body className={`${inter.variable} font-sans antialiased`}>
-        <ThemeProviderWrapper> {/* Wrap children with ThemeProviderWrapper */}
-          {children}
-          <Toaster />
-        </ThemeProviderWrapper>
+        <ViewportHeightWrapper>
+          <ThemeProviderWrapper>
+            {children}
+            <Toaster />
+          </ThemeProviderWrapper>
+        </ViewportHeightWrapper>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,10 @@ export default function Home() {
       className="flex justify-center items-center bg-gradient-to-br from-background to-secondary"
       style={{ minHeight: 'calc(var(--app-height, 100dvh))' }}
     >
-      <div className="w-full" style={{ height: 'calc(var(--app-height, 100dvh))' }}>
+      <div
+        className="w-full max-w-3xl mx-auto"
+        style={{ height: 'calc(var(--app-height, 100dvh))' }}
+      >
         <KGPTChat />
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,11 @@ import { KGPTChat } from '@/components/kgpt-chat/index'; // Explicitly point to 
 
 export default function Home() {
   return (
-    // Updated styling for overall page to use theme variables and fill the screen
-    <main className="flex justify-center items-center min-h-svh bg-gradient-to-br from-background to-secondary">
-      <div className="w-full h-svh">
+    <main
+      className="flex justify-center items-center bg-gradient-to-br from-background to-secondary"
+      style={{ minHeight: 'calc(var(--app-height, 100dvh))' }}
+    >
+      <div className="w-full" style={{ height: 'calc(var(--app-height, 100dvh))' }}>
         <KGPTChat />
       </div>
     </main>

--- a/src/components/kgpt-chat/ChatHeader.tsx
+++ b/src/components/kgpt-chat/ChatHeader.tsx
@@ -27,7 +27,10 @@ export function ChatHeader({ connectionStatus }: ChatHeaderProps) {
   };
 
   return (
-    <header className="sticky top-0 z-10 flex items-center justify-between px-4 py-3 border-b bg-card/80 backdrop-blur-md">
+    <header
+      className="sticky top-0 z-10 flex items-center justify-between px-4 py-3 border-b bg-card/80 backdrop-blur-md"
+      style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+    >
       <div className="flex items-center gap-2">
         <KGPTIcon className="h-7 w-7 text-primary" />
         <h1 className="text-xl font-headline font-semibold text-foreground">KGPT Chat</h1>

--- a/src/components/kgpt-chat/ChatInput.tsx
+++ b/src/components/kgpt-chat/ChatInput.tsx
@@ -63,7 +63,10 @@ export function ChatInput({ onSendMessage, isLoading }: ChatInputProps) {
   };
 
   return (
-    <div className="sticky bottom-0 left-0 right-0 p-3 sm:p-4 border-t bg-card/80 backdrop-blur-md">
+    <div
+      className="sticky bottom-0 left-0 right-0 p-3 sm:p-4 border-t bg-card/80 backdrop-blur-md"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.75rem)' }}
+    >
       <div className="flex items-end gap-2 relative">
         <Textarea
           ref={textareaRef}

--- a/src/components/viewport-height-wrapper.tsx
+++ b/src/components/viewport-height-wrapper.tsx
@@ -12,7 +12,11 @@ export function ViewportHeightWrapper({ children }: { children: React.ReactNode 
     };
     setHeight();
     window.addEventListener('resize', setHeight);
-    return () => window.removeEventListener('resize', setHeight);
+    window.addEventListener('orientationchange', setHeight);
+    return () => {
+      window.removeEventListener('resize', setHeight);
+      window.removeEventListener('orientationchange', setHeight);
+    };
   }, []);
 
   return <>{children}</>;

--- a/src/components/viewport-height-wrapper.tsx
+++ b/src/components/viewport-height-wrapper.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from 'react';
+
+export function ViewportHeightWrapper({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const setHeight = () => {
+      document.documentElement.style.setProperty(
+        '--app-height',
+        `${window.innerHeight}px`
+      );
+    };
+    setHeight();
+    window.addEventListener('resize', setHeight);
+    return () => window.removeEventListener('resize', setHeight);
+  }, []);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add ViewportHeightWrapper hook to adjust `--app-height`
- include wrapper in layout and set meta viewport `viewport-fit=cover`
- use `--app-height` CSS variable to size the main layout

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails to find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6855153d1a208321a423d8d4c9553749